### PR TITLE
feat: 観光スポット・現地ニュース情報の取得機能を実装

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -3,3 +3,5 @@ RESTCOUNTRIES_BASE_URL=https://restcountries.com/v3.1
 CACHE_TTL_HOURS=24
 MOFA_API_BASE_URL=
 CORS_ORIGINS=http://localhost:3000,http://localhost:3001
+GNEWS_API_KEY=your_gnews_api_key_here
+OTM_API_KEY=your_opentripmap_api_key_here

--- a/backend/app/api/attractions.py
+++ b/backend/app/api/attractions.py
@@ -1,19 +1,48 @@
 from fastapi import APIRouter, HTTPException
-from app.models.schemas import AttractionsResponse
+from app.models.schemas import EnrichedAttractionsResponse
 from app.services.ai_service import AIService
+from app.services.opentripmap import OpenTripMapService
 from app.services.restcountries import RestCountriesService
 
 router = APIRouter(prefix="/api/countries", tags=["attractions"])
 _ai_svc = AIService()
+_otm_svc = OpenTripMapService()
 _country_svc = RestCountriesService()
 
 
-@router.get("/{code}/attractions", response_model=AttractionsResponse)
+@router.get("/{code}/attractions", response_model=EnrichedAttractionsResponse)
 async def get_attractions(code: str):
     country = await _country_svc.get_country(code)
     if country is None:
         raise HTTPException(status_code=404, detail=f"国コード '{code}' は見つかりませんでした")
-    return await _ai_svc.generate_attractions(
-        country_code=country["code"],
-        country_name=country["name"],
+
+    ai_data, otm_spots = await _fetch_both(country)
+
+    return {
+        "country_code": country["code"],
+        "country_name": country["name"],
+        "otm_attractions": otm_spots,
+        "ai_summary": ai_data.get("ai_summary", []),
+        "best_season": ai_data.get("best_season"),
+        "travel_tips": ai_data.get("travel_tips", []),
+    }
+
+
+async def _fetch_both(country: dict) -> tuple[dict, list[dict]]:
+    """AI観光情報とOTM観光スポットを並行取得する。"""
+    import asyncio
+    ai_task = asyncio.create_task(
+        _ai_svc.generate_attractions(
+            country_code=country["code"],
+            country_name=country["name"],
+        )
     )
+    otm_task = asyncio.create_task(
+        _otm_svc.get_attractions(
+            country_code=country["code"],
+            latitude=country.get("latitude"),
+            longitude=country.get("longitude"),
+        )
+    )
+    ai_data, otm_spots = await asyncio.gather(ai_task, otm_task)
+    return ai_data, otm_spots

--- a/backend/app/api/news.py
+++ b/backend/app/api/news.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter, HTTPException
+from app.models.schemas import NewsResponse
+from app.services.gnews import GNewsService
+from app.services.restcountries import RestCountriesService
+
+router = APIRouter(prefix="/api/countries", tags=["news"])
+_gnews_svc = GNewsService()
+_country_svc = RestCountriesService()
+
+
+@router.get("/{code}/news", response_model=NewsResponse)
+async def get_news(code: str):
+    country = await _country_svc.get_country(code)
+    if country is None:
+        raise HTTPException(status_code=404, detail=f"国コード '{code}' は見つかりませんでした")
+    return await _gnews_svc.get_news(
+        country_code=country["code"],
+        country_name=country["name"],
+    )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -2,12 +2,14 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
 class Settings(BaseSettings):
-    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore", env_ignore_empty=True)
 
     anthropic_api_key: str = ""
     restcountries_base_url: str = "https://restcountries.com/v3.1"
     cache_ttl_hours: int = 24
     cors_origins: str = "http://localhost:3000"
+    gnews_api_key: str = ""
+    otm_api_key: str = ""
 
     @property
     def cors_origins_list(self) -> list[str]:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.api import countries, safety, attractions
+from app.api import countries, safety, attractions, news
 from app.core.config import settings
 
 app = FastAPI(
@@ -23,6 +23,7 @@ app.add_middleware(
 app.include_router(countries.router)
 app.include_router(safety.router)
 app.include_router(attractions.router)
+app.include_router(news.router)
 
 
 @app.get("/health", tags=["system"])

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -62,3 +62,36 @@ class AttractionsResponse(BaseModel):
     attractions: list[Attraction]
     best_season: str | None = None
     travel_tips: list[str]
+
+
+class OTMAttraction(BaseModel):
+    name: str
+    description: str | None = None
+    category: str | None = None
+    latitude: float | None = None
+    longitude: float | None = None
+    rating: float | None = None
+    wikipedia_url: str | None = None
+
+
+class EnrichedAttractionsResponse(BaseModel):
+    country_code: str
+    country_name: str
+    otm_attractions: list[OTMAttraction]
+    ai_summary: list[Attraction]
+    best_season: str | None = None
+    travel_tips: list[str]
+
+
+class NewsArticle(BaseModel):
+    title: str
+    description: str | None = None
+    url: str
+    source: str
+    published_at: str | None = None
+
+
+class NewsResponse(BaseModel):
+    country_code: str
+    articles: list[NewsArticle]
+    total: int

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -1,24 +1,115 @@
-"""Claude AI を使った観光スポット情報生成サービス"""
+"""観光スポット情報生成サービス（Claude AI または静的データ）"""
 from __future__ import annotations
 import json
 import re
-
-import anthropic
 
 from app.core.config import settings
 
 # インメモリキャッシュ（観光情報は頻繁に変わらないため長めにキャッシュ）
 _attractions_cache: dict[str, dict] = {}
 
+# 国別の静的観光情報データ（Claude APIが使えない場合のフォールバック）
+_STATIC_DATA: dict[str, dict] = {
+    "JP": {
+        "ai_summary": [
+            {"name": "富士山", "description": "日本のシンボルであり、世界文化遺産にも登録された標高3776mの活火山。5合目までバスでアクセス可能で、夏季は登山も楽しめる。", "category": "自然", "highlights": ["日本最高峰", "世界文化遺産", "ご来光"]},
+            {"name": "京都・嵐山", "description": "竹林の小径や渡月橋で有名な京都西郊の景勝地。天龍寺など多くの寺社が集まり、四季折々の自然美が楽しめる。", "category": "文化", "highlights": ["竹林の小径", "渡月橋", "天龍寺"]},
+            {"name": "沖縄・慶良間諸島", "description": "「ケラマブルー」と呼ばれる透明度抜群の海が広がる離島群。世界有数のダイビングスポットとして知られる。", "category": "アドベンチャー", "highlights": ["ケラマブルー", "ダイビング", "ウミガメ"]},
+            {"name": "屋久島", "description": "樹齢7200年の縄文杉が鎮座する世界自然遺産の島。苔むす原生林トレッキングは冒険心をくすぐる絶景体験。", "category": "自然", "highlights": ["縄文杉", "世界自然遺産", "原生林トレッキング"]},
+            {"name": "東京・渋谷・新宿", "description": "世界最大規模のスクランブル交差点や最先端のポップカルチャーが集まる東京の繁華街。夜景や食文化も充実。", "category": "都市", "highlights": ["スクランブル交差点", "ナイトライフ", "ストリートフード"]},
+        ],
+        "best_season": "春（3〜5月）の桜シーズンと秋（9〜11月）の紅葉シーズンが特に美しい。夏は花火大会や祭りが多い。",
+        "travel_tips": [
+            "ICカード（Suica / ICOCA）を購入すると電車・バス移動が格段に便利になります。",
+            "コンビニ（セブン・ファミマ・ローソン）はATMも兼ねており、24時間利用可能で非常に便利です。",
+            "飲食店でのチップは不要。むしろ渡すと失礼になることもあります。",
+            "地震対策として宿泊先の避難経路を確認しておきましょう。",
+            "SIMフリーのポケットWi-Fiをレンタルするとどこでもネット接続できます。",
+        ],
+    },
+    "US": {
+        "ai_summary": [
+            {"name": "グランドキャニオン", "description": "コロラド川が数百万年かけて刻んだ全長446kmの大峡谷。ヘリコプターツアーやラフティングなど冒険的な体験が充実。", "category": "自然", "highlights": ["世界遺産", "ヘリコプターツアー", "ラフティング"]},
+            {"name": "イエローストーン国立公園", "description": "世界初の国立公園。間欠泉「オールド・フェイスフル」やバイソンの群れなど、野生の自然が色濃く残る。", "category": "自然", "highlights": ["間欠泉", "野生動物", "温泉地帯"]},
+            {"name": "ニューヨーク・マンハッタン", "description": "自由の女神、タイムズスクエア、セントラルパークなど世界的名所が集中。食文化・芸術・エンタメの最前線。", "category": "都市", "highlights": ["自由の女神", "タイムズスクエア", "ブロードウェイ"]},
+            {"name": "ラスベガス", "description": "砂漠に突如現れる不夜城。カジノ、世界クラスのショー、美食レストランが集積するエンタメ都市。", "category": "都市", "highlights": ["カジノ", "ショー", "グランドキャニオンへのアクセス拠点"]},
+            {"name": "ハワイ・ビッグアイランド", "description": "活火山キラウエアが今も噴火を続ける島。溶岩フィールドのトレッキングは他の国立公園では体験できない体験。", "category": "アドベンチャー", "highlights": ["キラウエア火山", "溶岩トレッキング", "星空観察"]},
+        ],
+        "best_season": "地域によって異なるが、春（4〜5月）と秋（9〜10月）が気候的に過ごしやすい。夏は観光ピークで混雑する。",
+        "travel_tips": [
+            "チップ文化が根付いており、レストランでは請求額の15〜20%が目安です。",
+            "医療費が非常に高いため、旅行保険への加入は必須です。",
+            "広大な国土のため、移動手段として国内線や長距離バス（グレイハウンド）の利用を検討しましょう。",
+            "州によってガンの規制・大麻規制などルールが異なります。",
+            "クレジットカードはほぼ全店舗で使用可能。現金はほぼ不要です。",
+        ],
+    },
+    "FR": {
+        "ai_summary": [
+            {"name": "エッフェル塔", "description": "パリの象徴。夜間のライトアップは特に幻想的で、毎時間5分間の点滅イルミネーションは世界的に有名。", "category": "歴史", "highlights": ["夜間ライトアップ", "展望台", "セーヌ川クルーズとの組み合わせ"]},
+            {"name": "ルーヴル美術館", "description": "世界最大級の美術館。モナ・リザやミロのヴィーナスなど3万5千点以上の作品を所蔵。事前予約必須。", "category": "文化", "highlights": ["モナ・リザ", "ミロのヴィーナス", "世界最大の美術館"]},
+            {"name": "モンサンミッシェル", "description": "満潮時に孤島となる幻想的な修道院島。ノルマンディー海岸の世界遺産で、満潮・干潮のタイミングに合わせた訪問が必須。", "category": "世界遺産", "highlights": ["満潮時の絶景", "中世の修道院", "世界遺産"]},
+            {"name": "プロヴァンス・ラベンダー畑", "description": "7月にはヴァランソールなどの丘一面が紫に染まるラベンダー畑が広がる。レンタカーでの周遊がおすすめ。", "category": "自然", "highlights": ["ラベンダー畑", "7月が見頃", "ロゼワイン産地"]},
+            {"name": "シャモニー・モンブラン", "description": "ヨーロッパ最高峰モンブランのお膝元。ロープウェイで標高3842mのエギーユ・デュ・ミディへアクセスでき、雄大なアルプスを一望できる。", "category": "アドベンチャー", "highlights": ["モンブラン", "ロープウェイ", "スキー・ハイキング"]},
+        ],
+        "best_season": "春（4〜6月）と初秋（9〜10月）が観光に最適。7〜8月は混雑と猛暑に注意。ラベンダーは7月が見頃。",
+        "travel_tips": [
+            "パリの地下鉄（メトロ）は10枚回数券（carnet）を購入すると割安になります。",
+            "レストランでのランチはプリフィクスメニューを利用するとコスパよく食事できます。",
+            "スリに注意。特にエッフェル塔周辺や地下鉄内では貴重品管理を徹底してください。",
+            "多くの美術館は月曜または火曜が定休日。事前に確認を。",
+            "フランス語で「ボンジュール（Bonjour）」と一言挨拶するだけで現地の人の態度が変わります。",
+        ],
+    },
+    "TH": {
+        "ai_summary": [
+            {"name": "バンコク王宮・ワット・プラケオ", "description": "エメラルド仏を祀るタイ最神聖の寺院と宮殿群。金色に輝く仏塔と精緻な装飾は圧巻の美しさ。", "category": "宗教", "highlights": ["エメラルド仏", "王宮", "チャオプラヤー川クルーズとの組み合わせ"]},
+            {"name": "チェンマイ山岳トレッキング", "description": "ドイインタノン国立公園でのトレッキングや少数民族の村訪問など、バンコクとは全く異なる北タイの自然と文化を体験。", "category": "アドベンチャー", "highlights": ["少数民族の村", "象乗り体験", "タイ最高峰"]},
+            {"name": "クラビ・ライレイビーチ", "description": "石灰岩の断崖に囲まれた秘境ビーチ。船でしかアクセスできず、エメラルドグリーンの海とロッククライミングが楽しめる。", "category": "アドベンチャー", "highlights": ["秘境ビーチ", "ロッククライミング", "スノーケリング"]},
+            {"name": "アユタヤ遺跡", "description": "14世紀から18世紀まで繁栄したアユタヤ王朝の首都遺跡群。木に覆われた仏頭など独特の景観が世界遺産に登録。", "category": "世界遺産", "highlights": ["木の根に覆われた仏頭", "世界遺産", "バンコクから日帰り可"]},
+            {"name": "コ・タオ・ダイビング", "description": "世界最安値級のダイビングライセンス取得地として有名。透明度が高くウミガメも多い初心者に最適なダイビングスポット。", "category": "アドベンチャー", "highlights": ["格安ダイビングライセンス", "ウミガメ", "美しいサンゴ礁"]},
+        ],
+        "best_season": "11月〜2月が乾季で最も快適。3〜5月は酷暑、6〜10月は雨季（南部は特に雨量多）。",
+        "travel_tips": [
+            "仏像や寺院での撮影時は肌の露出に注意。タンクトップや短パンでは入場不可な寺院も多い。",
+            "タクシーはメーター使用を必ず要求。「いくら？」と先に聞いてくる運転手は避けましょう。",
+            "屋台料理は衛生面より混雑している店（地元民が多い）を選ぶ方が安全で美味しい。",
+            "水道水は飲めないためペットボトル水を常備する。コンビニで安価に購入可能。",
+            "グラブ（Grab）アプリが配車サービスとして非常に便利。ぼったくり防止にもなる。",
+        ],
+    },
+    "IT": {
+        "ai_summary": [
+            {"name": "コロッセオ（ローマ）", "description": "古代ローマ最大の円形闘技場。収容人数5万人の巨大建造物で、地下通路や剣闘士の控え室も見学可能。", "category": "歴史", "highlights": ["古代ローマ最大の闘技場", "地下見学ツアー", "フォロ・ロマーノとセット"]},
+            {"name": "ヴェネツィア水上都市", "description": "118の島に170本の運河が走る水上都市。ゴンドラでの運河巡りやカーニバル時期の仮面祭は世界的に有名。", "category": "文化", "highlights": ["ゴンドラ", "カーニバル（2月）", "サン・マルコ広場"]},
+            {"name": "アマルフィ海岸", "description": "断崖絶壁に張り付く色鮮やかな村々が続くイタリア南部の絶景海岸。レモンチェッロの産地でもある。", "category": "自然", "highlights": ["絶景ドライブ", "レモンチェッロ", "世界遺産"]},
+            {"name": "ドロミーティ山塊", "description": "ユネスコ世界自然遺産の石灰岩山群。夏はハイキング、冬はスキーリゾートとして世界中の冒険者が集まる。", "category": "アドベンチャー", "highlights": ["世界自然遺産", "ハイキング・スキー", "「Via Ferrata」ルート"]},
+            {"name": "シチリア島・エトナ山", "description": "ヨーロッパ最大の活火山で、今も噴煙を上げる。ガイドツアーでの山頂アタックは唯一無二の体験。", "category": "アドベンチャー", "highlights": ["活火山", "山頂トレッキング", "火口見学"]},
+        ],
+        "best_season": "春（4〜6月）と秋（9〜10月）が観光に最適。7〜8月はローマ・南部が酷暑で観光客も最多。",
+        "travel_tips": [
+            "コロッセオ・ウフィツィ美術館などは事前オンライン予約が必須。当日券は長蛇の列。",
+            "スリが非常に多い。リュックは前に抱える、財布はフロントポケットへ。",
+            "バール（BAR）での立ち飲みコーヒーはテーブル席の半額以下。地元スタイルを体験しよう。",
+            "レストランのコペルト（席料）は1〜3ユーロ/人が相場。サービス料とは別です。",
+            "公共交通のバリデート（刻印）を忘れると無賃乗車扱いで罰金になります。",
+        ],
+    },
+}
+
 
 class AIService:
     def __init__(self) -> None:
-        self._client: anthropic.Anthropic | None = None
+        self._client = None
 
     @property
-    def client(self) -> anthropic.Anthropic:
-        if self._client is None:
-            self._client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
+    def client(self):
+        if self._client is None and settings.anthropic_api_key:
+            try:
+                import anthropic
+                self._client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
+            except Exception:
+                self._client = None
         return self._client
 
     async def generate_attractions(self, country_code: str, country_name: str) -> dict:
@@ -26,12 +117,26 @@ class AIService:
         if cache_key in _attractions_cache:
             return _attractions_cache[cache_key]
 
+        # Anthropic APIが利用可能な場合はAI生成を試みる
+        if self.client:
+            result = await self._generate_with_ai(country_code, country_name)
+            if result:
+                _attractions_cache[cache_key] = result
+                return result
+
+        # 静的データを使用
+        result = self._get_static_data(country_code, country_name)
+        _attractions_cache[cache_key] = result
+        return result
+
+    async def _generate_with_ai(self, country_code: str, country_name: str) -> dict | None:
+        """Claude AIで観光情報を生成する。失敗時はNoneを返す。"""
         prompt = f"""\
 {country_name}（国コード: {country_code}）を旅行する日本人旅行者向けに、観光情報をJSON形式で提供してください。
 
 以下のJSONフォーマットで回答してください（JSONのみ、他のテキストなし）:
 {{
-  "attractions": [
+  "ai_summary": [
     {{
       "name": "観光地名",
       "description": "100文字程度の説明",
@@ -58,34 +163,36 @@ class AIService:
                 messages=[{"role": "user", "content": prompt}],
             )
             raw_text = message.content[0].text.strip()
-            # JSONブロック抽出
             json_match = re.search(r"\{[\s\S]*\}", raw_text)
             if json_match:
                 raw_text = json_match.group()
-            attractions_data = json.loads(raw_text)
-        except Exception:
-            # AI生成失敗時のフォールバック
-            attractions_data = {
-                "attractions": [
-                    {
-                        "name": f"{country_name}の主要観光地",
-                        "description": f"{country_name}を代表する観光スポットです。",
-                        "category": "文化",
-                        "highlights": ["現地文化", "歴史的建造物", "地元料理"],
-                    }
-                ],
-                "best_season": "現地の観光局にお問い合わせください。",
-                "travel_tips": [
-                    "旅行前に現地の気候を確認してください。",
-                    "現地通貨を用意しておくと便利です。",
-                    "旅行保険への加入を強くお勧めします。",
-                ],
+            data = json.loads(raw_text)
+            return {
+                "country_code": country_code.upper(),
+                "country_name": country_name,
+                **data,
             }
+        except Exception:
+            return None
 
-        result = {
-            "country_code": country_code.upper(),
+    def _get_static_data(self, country_code: str, country_name: str) -> dict:
+        """静的データまたはデフォルトフォールバックを返す。"""
+        code = country_code.upper()
+        if code in _STATIC_DATA:
+            return {
+                "country_code": code,
+                "country_name": country_name,
+                **_STATIC_DATA[code],
+            }
+        # 静的データもない場合の汎用フォールバック
+        return {
+            "country_code": code,
             "country_name": country_name,
-            **attractions_data,
+            "ai_summary": [],
+            "best_season": None,
+            "travel_tips": [
+                "旅行前に現地の気候・治安情報を確認してください。",
+                "現地通貨と旅行保険の準備をお忘れなく。",
+                "外務省の海外安全情報も必ずチェックしてください。",
+            ],
         }
-        _attractions_cache[cache_key] = result
-        return result

--- a/backend/app/services/gnews.py
+++ b/backend/app/services/gnews.py
@@ -1,0 +1,173 @@
+"""ニュース取得サービス（Google News RSS 利用、APIキー不要）"""
+from __future__ import annotations
+import re
+import time
+import xml.etree.ElementTree as ET
+from typing import Any
+
+import httpx
+
+from app.core.config import settings
+
+_GNEWS_BASE = "https://gnews.io/api/v4"
+_GOOGLE_NEWS_RSS = "https://news.google.com/rss/search"
+
+# インメモリキャッシュ（ニュースは1時間で更新）
+_news_cache: dict[str, tuple[Any, float]] = {}
+_NEWS_CACHE_TTL_HOURS = 1
+
+
+def _is_expired(ts: float) -> bool:
+    return time.time() - ts > _NEWS_CACHE_TTL_HOURS * 3600
+
+
+class GNewsService:
+    async def get_news(self, country_code: str, country_name: str, max_results: int = 10) -> dict:
+        """国のニュースを取得する。GNews APIキーがあればそちらを優先、なければGoogle News RSSを使用。"""
+        cache_key = country_code.upper()
+        if cache_key in _news_cache:
+            data, ts = _news_cache[cache_key]
+            if not _is_expired(ts):
+                return data
+
+        if settings.gnews_api_key:
+            articles = await self._fetch_from_gnews(country_name, max_results)
+        else:
+            articles = await self._fetch_from_google_rss(country_code, country_name, max_results)
+
+        result = {
+            "country_code": country_code.upper(),
+            "articles": articles,
+            "total": len(articles),
+        }
+        _news_cache[cache_key] = (result, time.time())
+        return result
+
+    async def _fetch_from_gnews(self, country_name: str, max_results: int) -> list[dict]:
+        """GNews APIからニュース記事を取得する。"""
+        for lang in ("ja", "en"):
+            try:
+                async with httpx.AsyncClient(timeout=10.0) as client:
+                    resp = await client.get(
+                        f"{_GNEWS_BASE}/search",
+                        params={
+                            "q": country_name,
+                            "lang": lang,
+                            "max": min(max_results, 10),
+                            "apikey": settings.gnews_api_key,
+                            "sortby": "publishedAt",
+                        },
+                    )
+                    if resp.status_code == 403:
+                        break
+                    resp.raise_for_status()
+                    data = resp.json()
+                    raw_articles = data.get("articles", [])
+                    if raw_articles:
+                        return [_parse_gnews_article(a) for a in raw_articles]
+            except Exception:
+                continue
+        return []
+
+    async def _fetch_from_google_rss(
+        self, country_code: str, country_name: str, max_results: int
+    ) -> list[dict]:
+        """Google News RSSからニュースを取得する（APIキー不要）。"""
+        articles: list[dict] = []
+
+        # 日本語ニュースを試みる（国コードに基づいて言語を設定）
+        query_sets = [
+            (country_name, "ja", "JP"),  # 日本語
+            (country_name, "en", "US"),  # 英語
+        ]
+
+        for query, hl_lang, gl_country in query_sets:
+            try:
+                fetched = await self._fetch_rss(query, hl_lang, gl_country, max_results)
+                if fetched:
+                    articles = fetched
+                    break
+            except Exception:
+                continue
+
+        return articles[:max_results]
+
+    async def _fetch_rss(
+        self, query: str, hl: str, gl: str, limit: int
+    ) -> list[dict]:
+        ceid = f"{gl}:{hl}"
+        async with httpx.AsyncClient(
+            timeout=10.0,
+            headers={"User-Agent": "Mozilla/5.0 (compatible; TravelApp/1.0)"},
+            follow_redirects=True,
+        ) as client:
+            resp = await client.get(
+                _GOOGLE_NEWS_RSS,
+                params={"q": query, "hl": hl, "gl": gl, "ceid": ceid},
+            )
+            resp.raise_for_status()
+            return _parse_rss(resp.text, limit)
+
+
+def _parse_rss(xml_text: str, limit: int) -> list[dict]:
+    """Google News RSS XMLを解析して記事リストに変換する。"""
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError:
+        return []
+
+    channel = root.find("channel")
+    if channel is None:
+        return []
+
+    articles = []
+    for item in channel.findall("item")[:limit]:
+        title_el = item.find("title")
+        link_el = item.find("link")
+        desc_el = item.find("description")
+        pub_el = item.find("pubDate")
+        source_el = item.find("source")
+
+        title = title_el.text if title_el is not None else ""
+        if not title:
+            continue
+
+        # Google News RSSの title には "記事タイトル - メディア名" 形式が多い
+        source_from_title = ""
+        if " - " in title:
+            parts = title.rsplit(" - ", 1)
+            title = parts[0].strip()
+            source_from_title = parts[1].strip()
+
+        source = (
+            source_el.text if source_el is not None and source_el.text
+            else source_from_title or "Google News"
+        )
+
+        description = None
+        if desc_el is not None and desc_el.text:
+            # HTMLタグを除去
+            description = re.sub(r"<[^>]+>", "", desc_el.text).strip()
+            if not description:
+                description = None
+
+        articles.append({
+            "title": title,
+            "description": description,
+            "url": link_el.text if link_el is not None else "",
+            "source": source,
+            "published_at": pub_el.text if pub_el is not None else None,
+        })
+
+    return articles
+
+
+def _parse_gnews_article(raw: dict) -> dict:
+    source = raw.get("source", {})
+    return {
+        "title": raw.get("title", ""),
+        "description": raw.get("description"),
+        "url": raw.get("url", ""),
+        "source": source.get("name", "") if isinstance(source, dict) else str(source),
+        "published_at": raw.get("publishedAt"),
+    }

--- a/backend/app/services/opentripmap.py
+++ b/backend/app/services/opentripmap.py
@@ -1,0 +1,130 @@
+"""OpenTripMap API 連携サービス"""
+from __future__ import annotations
+import time
+from typing import Any
+
+import httpx
+
+from app.core.config import settings
+
+_OTM_BASE = "https://api.opentripmap.com/0.1/en/places"
+
+# インメモリキャッシュ
+_otm_cache: dict[str, tuple[Any, float]] = {}
+
+
+def _is_expired(ts: float) -> bool:
+    return time.time() - ts > settings.cache_ttl_hours * 3600
+
+
+class OpenTripMapService:
+    async def get_attractions(
+        self,
+        country_code: str,
+        latitude: float | None,
+        longitude: float | None,
+        limit: int = 10,
+    ) -> list[dict]:
+        """指定した国の観光スポットを取得する。APIキーがない場合や失敗時は空リストを返す。"""
+        if not settings.otm_api_key:
+            return []
+        if latitude is None or longitude is None:
+            return []
+
+        cache_key = f"otm_{country_code.upper()}"
+        if cache_key in _otm_cache:
+            data, ts = _otm_cache[cache_key]
+            if not _is_expired(ts):
+                return data
+
+        try:
+            spots = await self._fetch_radius(latitude, longitude, limit)
+            enriched = await self._enrich_spots(spots[:limit])
+            _otm_cache[cache_key] = (enriched, time.time())
+            return enriched
+        except Exception:
+            return []
+
+    async def _fetch_radius(
+        self, lat: float, lon: float, limit: int
+    ) -> list[dict]:
+        """国の中心付近の観光スポット一覧を取得する。"""
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            resp = await client.get(
+                f"{_OTM_BASE}/radius",
+                params={
+                    "apikey": settings.otm_api_key,
+                    "radius": 500000,  # 500km 半径
+                    "lon": lon,
+                    "lat": lat,
+                    "kinds": "interesting_places",
+                    "rate": "3",  # 重要度フィルタ（3=高評価のみ）
+                    "format": "json",
+                    "limit": limit * 2,  # 絞り込みのため多めに取得
+                },
+            )
+            resp.raise_for_status()
+            return resp.json()
+
+    async def _enrich_spots(self, spots: list[dict]) -> list[dict]:
+        """各スポットの詳細情報を取得してマッピングする。"""
+        result = []
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            for spot in spots:
+                xid = spot.get("xid")
+                if not xid:
+                    continue
+                name = spot.get("name", "").strip()
+                if not name:
+                    continue
+                try:
+                    detail_resp = await client.get(
+                        f"{_OTM_BASE}/xid/{xid}",
+                        params={"apikey": settings.otm_api_key},
+                    )
+                    detail_resp.raise_for_status()
+                    detail = detail_resp.json()
+                except Exception:
+                    detail = {}
+
+                point = spot.get("point", {})
+                wikipedia_extracts = detail.get("wikipedia_extracts", {})
+                description = wikipedia_extracts.get("text") or detail.get("info", {}).get("descr")
+                kinds_str = detail.get("kinds", spot.get("kinds", ""))
+                category = _map_kind(kinds_str)
+
+                result.append({
+                    "name": name,
+                    "description": description[:200] if description else None,
+                    "category": category,
+                    "latitude": point.get("lat"),
+                    "longitude": point.get("lon"),
+                    "rating": spot.get("rate"),
+                    "wikipedia_url": detail.get("wikipedia"),
+                })
+
+        return result
+
+
+def _map_kind(kinds: str) -> str | None:
+    """OpenTripMapのkindストリングをカテゴリ文字列にマッピングする。"""
+    if not kinds:
+        return None
+    kinds_lower = kinds.lower()
+    if "natural" in kinds_lower or "nature" in kinds_lower:
+        return "自然"
+    if "architecture" in kinds_lower or "historic" in kinds_lower or "castle" in kinds_lower:
+        return "歴史"
+    if "religion" in kinds_lower or "temple" in kinds_lower or "church" in kinds_lower:
+        return "宗教"
+    if "museum" in kinds_lower or "cultural" in kinds_lower or "art" in kinds_lower:
+        return "文化"
+    if "food" in kinds_lower or "restaurant" in kinds_lower:
+        return "食"
+    if "sport" in kinds_lower or "amusement" in kinds_lower:
+        return "アドベンチャー"
+    if "urban" in kinds_lower or "city" in kinds_lower:
+        return "都市"
+    if "world_heritage" in kinds_lower:
+        return "世界遺産"
+    return None

--- a/backend/app/services/restcountries.py
+++ b/backend/app/services/restcountries.py
@@ -209,7 +209,7 @@ class RestCountriesService:
             try:
                 resp = await client.get(
                     f"{self.base_url}/alpha/{code}",
-                    params={"fields": "name,cca2,flags,flag,capital,region,subregion,population,languages,currencies"},
+                    params={"fields": "name,cca2,flags,flag,capital,region,subregion,population,languages,currencies,latlng"},
                 )
                 if resp.status_code == 404:
                     return None


### PR DESCRIPTION
- attractions エンドポイントを EnrichedAttractionsResponse 形式に変更
  - OpenTripMap API 連携で実際の観光スポット（OTM）を取得
  - AI生成スポットを ai_summary フィールドで返すよう修正
  - AI・OTMを並行取得してレスポンスを構成
- ニュース取得機能を新規実装
  - GET /api/countries/{code}/news エンドポイントを追加
  - GNews API 対応（APIキー設定時）
  - Google News RSS フォールバック（APIキー不要）
- Claude API クレジット不足時の静的データフォールバックを追加
  - JP/US/FR/TH/IT の主要5か国の観光情報を内蔵
- config.py に env_ignore_empty=True を追加（空の環境変数を無視）
- gnews_api_key / otm_api_key を設定に追加