### PR TITLE
fix: backend Dockerfileのビルドエラーを修正

### DIFF
--- a/Dockerfiles/backend.Dockerfile
+++ b/Dockerfiles/backend.Dockerfile
@@ -2,12 +2,10 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-# 依存関係ファイルをコピーしてインストール
+# 依存関係ファイルとソースコードをコピーしてインストール
 COPY backend/pyproject.toml .
-RUN pip install --no-cache-dir -e .
-
-# アプリケーションコードをコピー
 COPY backend/app/ ./app/
+RUN pip install --no-cache-dir .
 
 EXPOSE 8000
 

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -11,8 +11,6 @@ class Settings(BaseSettings):
     otm_api_key: str = ""
     news_cache_ttl_minutes: int = 30
     cors_origins: str = "http://localhost:3000"
-    gnews_api_key: str = ""
-    otm_api_key: str = ""
 
     @property
     def cors_origins_list(self) -> list[str]:


### PR DESCRIPTION
- ソースコード(app/)をpip install前にコピーするよう順序を修正
  (hatchlingがapp/パッケージを参照するため、コピー前だとビルド失敗)
- editable install(-e)を通常インストールに変更(本番環境では不要)
- config.pyのgnews_api_key/otm_api_keyの重複定義を削除

https://claude.ai/code/session_01CTxJPtbDjpugMLg6wug5Bf